### PR TITLE
Add scaling for fHS heat source

### DIFF
--- a/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/chtMultiRegionSimpleFoamVHH/solid/solveSolid.H
+++ b/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/chtMultiRegionSimpleFoamVHH/solid/solveSolid.H
@@ -10,7 +10,7 @@
             )
           ==
             fvOptions(rho, h)
-            + fHS //additional heat sources from fHS field
+            + corrFHS //additional heat sources from fHS field
         );
 
         hEqn.relax();

--- a/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/solid/createSolidFields.H
+++ b/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/solid/createSolidFields.H
@@ -4,8 +4,12 @@ PtrList<solidThermo> thermos(solidRegions.size());
 PtrList<radiation::radiationModel> radiations(solidRegions.size());
 PtrList<fv::options> solidHeatSources(solidRegions.size());
 PtrList<volScalarField> fieldSolidHS(solidRegions.size());
+PtrList<volScalarField> corrFieldSolidHS(solidRegions.size());
 PtrList<volScalarField> betavSolid(solidRegions.size());
 PtrList<volSymmTensorField> aniAlphas(solidRegions.size());
+PtrList<scalar> resistivityRho1(solidRegions.size());
+PtrList<scalar> resistivityRho0(solidRegions.size());
+PtrList<scalar> resistivityTref(solidRegions.size());
 
 List<bool> residualReachedSolid(solidRegions.size(), true);
 List<bool> residualControlUsedSolid(solidRegions.size(), false);
@@ -45,6 +49,24 @@ forAll(solidRegions, i)
             ),
             solidRegions[i]
         )
+    );
+
+    corrFieldSolidHS.set
+    (
+	i,
+	new volScalarField
+	(
+	    IOobject
+	    (
+		"corrFieldSolidHS",
+		runTime.timeName(),
+		solidRegions[i],
+		IOobject::NO_READ,
+		IOobject::NO_WRITE
+	    ),
+	    solidRegions[i],
+	    dimensionedScalar("corrFieldSolidHS", dimPower/dimVolume, 0.0)
+	)
     );
 
     if (!thermos[i].isotropic())
@@ -141,4 +163,10 @@ forAll(solidRegions, i)
 
         #include "readSolidMultiRegionResidualControls.H"
     }
+
+    // Read constants from thermophysicalProperties file
+    dictionary subDict = thermos[i].subOrEmptyDict("electricResistivity");
+    resistivityRho1.set(i, new scalar(subDict.lookupOrDefault("rho1", 0.0)));
+    resistivityRho0.set(i, new scalar(subDict.lookupOrDefault("rho0", 1.0)));
+    resistivityTref.set(i, new scalar(subDict.lookupOrDefault("Tref", 1.0)));
 }

--- a/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/solid/setRegionSolidFields.H
+++ b/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/solid/setRegionSolidFields.H
@@ -36,3 +36,13 @@ const volScalarField& fHS = fieldSolidHS[i];
 bool& resReachedSolid = residualReachedSolid[i];
 bool& residualControlUsed = residualControlUsedSolid[i];
 bool& firstIteration = firstIterationSolid[i];
+
+const scalar& resRho1 = resistivityRho1[i];
+const scalar& resRho0 = resistivityRho0[i];
+const scalar& resTref = resistivityTref[i];
+
+// Temperature is multiplied by 1.0 1/K to make volScalarfield Tm unitless
+const volScalarField Tm = thermo.T()* dimensionedScalar("Temp", dimless/dimTemperature, scalar(1.0)) ;
+
+volScalarField& corrFHS = corrFieldSolidHS[i];
+corrFHS = (resRho1 * Tm  + resRho0)/(resRho1 * resTref + resRho0) * fHS;

--- a/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/solid/solveSolid.H
+++ b/applications/solvers/heatTransfer/chtMultiRegionFoamVHH/solid/solveSolid.H
@@ -16,7 +16,7 @@ if (finalIter)
             )
           ==
             fvOptions(rho, h)
-            + fHS //additional heat sources from fHS field
+            + corrFHS //additional heat sources from fHS field
         );
 
         hEqn.relax();


### PR DESCRIPTION
Heat source fHS is computed at reference temperature Tr and assumed to
be linearly depend on resistivity rho(T).

  corr_fHS(T) = rho(T)/rho(Tref) * fHS

Linear material law is used for resistivity modeling resistivity
temperature dependence rho(T) = rho1 * T + rho0

Scaled heat source corr_fHS is:

  corr_fHS(Tm) = ((rho1 * Tm) + rho0)/((rho1 * Tref) + rho0) * fHS

Coefficient for scaling are defined in thermophysicallProperties file
using "electricResistivity" dictionary

Below is example of dictionary and default values used if dictionary is
not found.

    electricResistivity
    {
	rho1 0.0;
	rho0 1.0;
	Tref 1.0;
    }